### PR TITLE
Merge upstream changes from Type-on-Strap

### DIFF
--- a/.github/cli/e2e/screenshots.spec.ts
+++ b/.github/cli/e2e/screenshots.spec.ts
@@ -13,7 +13,11 @@ function defineScreenshotTests(): void {
   test('mermaid article', async ({ page }) => {
     await page.goto('/2016/12/03/Mermaid');
     await page.waitForSelector('.mermaid svg, .language-mermaid svg', { timeout: 15_000 });
-    await takeThemeScreenshots(page, 'mermaid-article');
+    await page.waitForFunction(() => {
+      const svgs = document.querySelectorAll('.mermaid svg, .language-mermaid svg');
+      return [...svgs].every(svg => svg.getBoundingClientRect().height > 0);
+    });
+    await takeThemeScreenshots(page, 'mermaid-article', { maxDiffPixelRatio: 0.01 });
   });
 
   test('katex article', async ({ page }) => {

--- a/.github/cli/e2e/support/helpers.ts
+++ b/.github/cli/e2e/support/helpers.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test, type Page, type PageAssertionsToHaveScreenshotOptions } from '@playwright/test';
 
 /**
  * Helper to open mobile menu - forces menu visibility for mobile tests
@@ -42,12 +42,12 @@ export async function setTheme(page: Page, theme: 'light' | 'dark'): Promise<voi
  * compared on subsequent runs (visual regression). Run with `--update-snapshots`
  * to create or refresh the baseline.
  */
-export async function takeThemeScreenshots(page: Page, name: string): Promise<void> {
+export async function takeThemeScreenshots(page: Page, name: string, options: PageAssertionsToHaveScreenshotOptions = {}): Promise<void> {
   await setTheme(page, 'light');
-  await expect(page).toHaveScreenshot(`${name}-light.png`, { fullPage: true });
+  await expect(page).toHaveScreenshot(`${name}-light.png`, { fullPage: true, ...options });
 
   await setTheme(page, 'dark');
-  await expect(page).toHaveScreenshot(`${name}-dark.png`, { fullPage: true });
+  await expect(page).toHaveScreenshot(`${name}-dark.png`, { fullPage: true, ...options });
 }
 
 /**

--- a/.github/workflows/e2e-visual.yml
+++ b/.github/workflows/e2e-visual.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           RUN_ID=$(gh run list \
             --repo ${{ github.repository }} \
-            --branch main \
+            --branch master \
             --workflow e2e-visual.yml \
             --status success \
             --limit 1 \

--- a/.github/workflows/e2e-visual.yml
+++ b/.github/workflows/e2e-visual.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Download snapshots from latest main run
+      - name: Download snapshots from latest master run
         id: snapshots
         continue-on-error: true
         env:

--- a/.github/workflows/gem-build.yml
+++ b/.github/workflows/gem-build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '3.2', '3.3', '3.4' ] # '4.0'
+        ruby: [ '3.2', '3.3', '3.4', '4.0' ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/gem-github-page.yml
+++ b/.github/workflows/gem-github-page.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.7.4', '3.4', '4.0' ]
+        ruby: [ '2.7.4', '4.0' ]
 
     steps:
       - uses: actions/checkout@v4

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,10 @@
 source "https://rubygems.org"
 
-# Should be included in Jekyll but depending on the version Jekyll and Ruby version, it may not be included
+# Required explicitly — removed from Ruby default gems in Ruby 3.2+ (webrick >= 1.9)
 gem 'webrick'
+# Required explicitly in Ruby 3.4+ (removed from default gems)
+gem 'base64'
+gem 'bigdecimal'
 
 # For github pages compatibility
 # gem 'github-pages', group: :jekyll_plugins

--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ Based on Rohan Chandra [type-theme](https://github.com/rohanchandra/type-theme) 
 
 ## Usage
 
+### As a remote theme
+
+The easiest way to use Type-on-Strap is as a remote theme with GitHub Pages.
+Add this to your [`_config.yml`](_config.yml):
+
+```yml
+remote_theme: sylhare/Type-on-Strap
+```
+
 ### As a GitHub page 📋
 
 1. Fork and clone the [Type on Strap repo](https://github.com/sylhare/Type-On-Strap): `git clone https://github.com/Sylhare/Type-on-Strap.git`
@@ -628,15 +637,6 @@ Then you can start adding content like:
   - Add a [`index.html`](index.html) file
   - Add the feature page you want. (ex: as it is already in `pages`)
   - Add posts in `_posts` and `_portfolio` to be displayed
-
-### Remote Theme
-
-Now you can use any theme gem with GitHub pages with [29/11/2017 GitHub Pages Broadcast](https://github.com/blog/2464-use-any-theme-with-github-pages).
-For that remove all `theme:` attributes from [`_config.yml`](_config.yml) and add instead:
-
-```yml
-remote_theme: sylhare/Type-on-Strap 
-```
 
 ## License
 


### PR DESCRIPTION
## Summary
- Merges 5 latest commits from [sylhare/Type-on-Strap](https://github.com/sylhare/Type-on-Strap)
- Updates gems and workflow files
- Brings in documentation improvements and e2e test fixes
- Keeps upstream's `e2e-visual.yml` workflow