### PR TITLE
Add bundler to dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,3 +9,11 @@ updates:
       actions:
         patterns:
           - "*"
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      gems:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Adds a `bundler` ecosystem entry to dependabot so Ruby gem updates are tracked
- Gems are checked monthly and grouped into a single PR to reduce noise